### PR TITLE
make markdown code fence long tick higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ content-switcher:
 
 Use divs with the `content-switcher` class to create version-specific content blocks:
 
-```markdown
+````markdown
 ::: {.content-switcher version="v2026.01"}
 ### Version 2026.01.0 Example
 
@@ -81,7 +81,7 @@ library(readr)
 data <- read_csv('data.csv')
 ```
 :::
-```
+````
 
 ### Inline Content Switching
 


### PR DESCRIPTION
I saw that the readme was a little hard to read because of the code fences. Hopefully this should fix it 🙌 

## before 

<img width="613" height="463" alt="Screenshot 2026-02-06 at 10 53 46 PM" src="https://github.com/user-attachments/assets/d0ebfa85-753a-4ba8-96c9-ada99690b6c9" />

## After

<img width="607" height="489" alt="Screenshot 2026-02-06 at 10 54 22 PM" src="https://github.com/user-attachments/assets/41f0883f-d06a-46be-a0f9-d738c25ff94a" />
