### PR TITLE
Search issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Use divs with the `content-switcher` class to create version-specific content bl
 
 ````markdown
 ::: {.content-switcher version="v2026.01"}
-### Version 2026.01.0 Example
+## Version 2026.01.0 Example {.unlisted}
 
 Use pandas to read CSV data:
 
@@ -72,7 +72,7 @@ data = pd.read_csv('data.csv')
 :::
 
 ::: {.content-switcher version="v2.0"}
-### Version 2.0 Example
+## Version 2.0 Example {.unlisted}
 
 Use readr to read CSV data:
 
@@ -83,7 +83,7 @@ data <- read_csv('data.csv')
 :::
 ````
 
-**Note:** Headings inside content-switcher blocks are automatically excluded from the table of contents. This prevents the TOC from showing headings that aren't currently visible when switching between versions.
+**Note:** Add `{.unlisted}` to headings to exclude them from the table of contents. Use level 2 headings (`##`) for content that should be searchable as separate entries (see Limitations section for details).
 
 ### Inline Content Switching
 
@@ -165,7 +165,24 @@ window.addEventListener('content-switcher:changed', function(event) {
 
 ## Limitations
 
-- **Table of Contents**: Headings inside content-switcher blocks are automatically excluded from the table of contents. This is necessary because Quarto's TOC system doesn't support dynamically updating which headings should be displayed. If you need version-specific sections in your TOC, consider placing the content-switcher blocks inside the sections rather than wrapping entire sections with headings.
+- **Table of Contents**: If you want to hide headings from the table of contents, you can manually add the `{.unlisted}` class to headings inside content-switcher blocks. This prevents the TOC from showing headings that aren't currently visible when switching between versions.
+
+- **Search Indexing**: Quarto's search feature only creates separate search entries for **level 2 headings (`##`)** and above. Level 3 headings (`###`) and below are included in their parent section's searchable text but won't appear as separate search results.
+
+  **Important**: If you want version-specific content blocks to be individually searchable, use level 2 headings (`##`) instead of level 3 or lower. If you use `{.unlisted}` on level 3+ headings, the content will still be searchable but won't appear as a separate search result entry.
+
+  Example for searchable version blocks:
+  ```markdown
+  ::: {.content-switcher version="v1.0"}
+  ## Version 1.0 Features {.unlisted}
+  Content here will be searchable as a separate entry.
+  :::
+
+  ::: {.content-switcher version="v2.0"}
+  ## Version 2.0 Features {.unlisted}
+  Content here will also be searchable as a separate entry.
+  :::
+  ```
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ data <- read_csv('data.csv')
 :::
 ````
 
-**Note:** Add `{.unlisted}` to headings to exclude them from the table of contents. Use level 2 headings (`##`) for content that should be searchable as separate entries (see Limitations section for details).
+**Important:** Always add `{.unlisted}` to headings inside content-switcher blocks to exclude them from the table of contents. Without this, the TOC will show headings for all versions simultaneously, even though only one version is visible at a time, leading to confusing TOC behavior.
+
+**Tip:** Use level 2 headings (`##`) for content blocks that should be individually searchable (see Limitations section for details about search indexing).
 
 ### Inline Content Switching
 
@@ -165,7 +167,7 @@ window.addEventListener('content-switcher:changed', function(event) {
 
 ## Limitations
 
-- **Table of Contents**: If you want to hide headings from the table of contents, you can manually add the `{.unlisted}` class to headings inside content-switcher blocks. This prevents the TOC from showing headings that aren't currently visible when switching between versions.
+- **Table of Contents**: Headings inside content-switcher blocks do not behave as expected in the table of contents. Quarto's TOC system cannot dynamically update to show only the currently visible version's headings. **You should always add `{.unlisted}` to headings inside content-switcher blocks** to prevent the TOC from displaying headings for all versions simultaneously, which creates a confusing user experience.
 
 - **Search Indexing**: Quarto's search feature only creates separate search entries for **level 2 headings (`##`)** and above. Level 3 headings (`###`) and below are included in their parent section's searchable text but won't appear as separate search results.
 

--- a/_extensions/content-switcher/content-switcher.js
+++ b/_extensions/content-switcher/content-switcher.js
@@ -36,16 +36,21 @@ document.addEventListener("DOMContentLoaded", function() {
     switchVersion(e.target.value);
   });
 
-  // Check for URL parameter first, then localStorage
+  // Check for URL parameter first, then localStorage, then default
   const urlParams = new URLSearchParams(window.location.search);
   const urlVersion = urlParams.get('version');
   const savedVersion = localStorage.getItem("content-switcher-selected-version");
 
+  let initialVersion = selector.value; // Use selector's default value
+
   if (urlVersion && validOptions.includes(urlVersion)) {
+    initialVersion = urlVersion;
     selector.value = urlVersion;
-    switchVersion(urlVersion);
   } else if (savedVersion && validOptions.includes(savedVersion)) {
+    initialVersion = savedVersion;
     selector.value = savedVersion;
-    switchVersion(savedVersion);
   }
+
+  // Initialize: hide all non-active versions on page load
+  switchVersion(initialVersion);
 });

--- a/_extensions/content-switcher/content-switcher.lua
+++ b/_extensions/content-switcher/content-switcher.lua
@@ -116,15 +116,16 @@ function generate_version_selector()
   return html
 end
 
--- Helper function to mark headers as unlisted
-local function mark_headers_unlisted(content)
-  return pandoc.walk_block(content, {
-    Header = function(header)
-      header.classes:insert("unlisted")
-      return header
-    end
-  })
-end
+-- Helper function to mark headers as unlisted (not used by default)
+-- Users can manually add {.unlisted} to headers if they want to exclude from TOC
+-- local function mark_headers_unlisted(content)
+--   return pandoc.walk_block(content, {
+--     Header = function(header)
+--       header.classes:insert("unlisted")
+--       return header
+--     end
+--   })
+-- end
 
 -- Helper function to process conditional elements (both Div and Span)
 local function process_conditional_element(element)
@@ -137,17 +138,10 @@ local function process_conditional_element(element)
   local version = element.attributes["version"] or default_version
   add_version_if_new(version)
 
-  -- For Div elements, mark any headers inside as unlisted to exclude from TOC
-  if element.t == "Div" then
-    element = mark_headers_unlisted(element)
-  end
-
   -- For HTML output, set up for dynamic switching
   if quarto.doc.is_format("html") then
-    if version ~= default_version then
-      element.classes:insert("content-switcher-hidden")
-    end
-
+    -- Don't add content-switcher-hidden class here to ensure all content
+    -- is indexed by Quarto's search. JavaScript will handle hiding.
     return element
   end
 

--- a/example.qmd
+++ b/example.qmd
@@ -37,6 +37,7 @@ print(data.head())
 ::: {.content-switcher version="v2.0"}
 ### version 2.0 example {.unlisted}
 
+This is a test for searching. I
 Use readr to read CSV data:
 
 ```r
@@ -47,7 +48,7 @@ head(data)
 :::
 
 ::: {.content-switcher version="v3.0"}
-### version 3.0 Example {.unlisted}
+## version 3.0 Example {.unlisted}
 
 Use CSV.jl to read CSV data:
 


### PR DESCRIPTION
- removes "auto-hide" feature for headings since it was negatively impacting search indexing
- added readme content about search behavior (h3s and below `unlisted` are not indexed / searchable)